### PR TITLE
Add "Login Instructions" link and modal view to LoginView

### DIFF
--- a/SustainU.xcodeproj/project.pbxproj
+++ b/SustainU.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		2BD5A2EF2CD17C18009D9624 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD5A2EE2CD17C18009D9624 /* KeychainService.swift */; };
 		2BD5A2F22CD17EAB009D9624 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 2BD5A2F12CD17EAB009D9624 /* KeychainAccess */; };
 		2BD5A2F42CD188A7009D9624 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD5A2F32CD188A7009D9624 /* NetworkMonitor.swift */; };
+		2BD5A2F62CD57BD3009D9624 /* LoginInstructionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD5A2F52CD57BD3009D9624 /* LoginInstructionsView.swift */; };
 		2BED14C22CA89D90003F1862 /* ProfileModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BED14B92CA89D90003F1862 /* ProfileModel.swift */; };
 		2BED14C32CA89D90003F1862 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BED14BA2CA89D90003F1862 /* ContentView.swift */; };
 		2BED14C52CA89D90003F1862 /* GridMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BED14BC2CA89D90003F1862 /* GridMenuView.swift */; };
@@ -97,6 +98,7 @@
 		2BD5A2EC2CD17889009D9624 /* ConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityManager.swift; sourceTree = "<group>"; };
 		2BD5A2EE2CD17C18009D9624 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		2BD5A2F32CD188A7009D9624 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		2BD5A2F52CD57BD3009D9624 /* LoginInstructionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginInstructionsView.swift; sourceTree = "<group>"; };
 		2BED14B92CA89D90003F1862 /* ProfileModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileModel.swift; sourceTree = "<group>"; };
 		2BED14BA2CA89D90003F1862 /* ContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		2BED14BC2CA89D90003F1862 /* GridMenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridMenuView.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 		A108714B2CAE13FC008312B0 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				2BED14BD2CA89D90003F1862 /* LoginView.swift */,
 				2BD5A2EA2CC2C1F7009D9624 /* ProfileView.swift */,
 				2BED14BE2CA89D90003F1862 /* CameraView.swift */,
 				A177611F2CC1AAF300F10420 /* CameraPopupView.swift */,
@@ -212,8 +215,8 @@
 				A10871472CAE0F5D008312B0 /* ExpandableSearchView.swift */,
 				A108713F2CAE0F09008312B0 /* CollectionPointDetailView.swift */,
 				2BED14C02CA89D90003F1862 /* HomeView.swift */,
-				2BED14BD2CA89D90003F1862 /* LoginView.swift */,
 				A108714C2CAE15EE008312B0 /* UIKit */,
+				2BD5A2F52CD57BD3009D9624 /* LoginInstructionsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -270,12 +273,12 @@
 			isa = PBXGroup;
 			children = (
 				2BD5A2E82CC2C01D009D9624 /* LaunchScreen.storyboard */,
-				A1381FC62CC1F74F0045993C /* Viewmodels */,
 				A17760EB2CC19CCA00F10420 /* GoogleService-Info.plist */,
 				2BED14BF2CA89D90003F1862 /* Auth0.plist */,
 				2BED14CB2CA89DDB003F1862 /* SustainUApp.swift */,
 				A10871392CAE0EC5008312B0 /* APIConfig.swift */,
 				A17760E72CC027C300F10420 /* Location.gpx */,
+				A1381FC62CC1F74F0045993C /* Viewmodels */,
 				A10871512CAE1683008312B0 /* Resources */,
 				A10871492CAE1387008312B0 /* Services */,
 				CD7FB2852CA8A3F000EE6601 /* Models */,
@@ -510,6 +513,7 @@
 				A10871402CAE0F09008312B0 /* CollectionPointDetailView.swift in Sources */,
 				2BED14C32CA89D90003F1862 /* ContentView.swift in Sources */,
 				2BED14C52CA89D90003F1862 /* GridMenuView.swift in Sources */,
+				2BD5A2F62CD57BD3009D9624 /* LoginInstructionsView.swift in Sources */,
 				A10871462CAE0F54008312B0 /* SearchViewController.swift in Sources */,
 				A108713E2CAE0F04008312B0 /* LocationManager.swift in Sources */,
 				A17761202CC1AAF300F10420 /* CameraPopupView.swift in Sources */,

--- a/SustainU/Views/LoginInstructionsView.swift
+++ b/SustainU/Views/LoginInstructionsView.swift
@@ -1,0 +1,53 @@
+//
+//  LoginInstructionsView.swift
+//  SustainU
+//
+//  Created by Duarte Mantilla Ernesto Jose on 1/11/24.
+//
+
+import Foundation
+import SwiftUI
+
+struct LoginInstructionsView: View {
+    @Environment(\.presentationMode) var presentationMode  // To dismiss the view
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("Login Instructions")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .padding(.bottom, 20)
+            
+            Text("1. The email must belong to the @uniandes.edu.co domain.")
+                .font(.body)
+            Text("2. The email must not contain special characters except \".\", \"-\", and \"_\".")
+                .font(.body)
+            Text("3. The name must not have special characters and must have between 3 and 50 characters.")
+                .font(.body)
+            
+            Spacer()
+            
+            // Optional: Add a close button
+            Button(action: {
+                presentationMode.wrappedValue.dismiss()
+            }) {
+                Text("Close")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(Color("greenLogoColor"))
+                    .cornerRadius(15.0)
+            }
+            .padding(.bottom, 20)
+        }
+        .padding()
+        .navigationBarTitle("", displayMode: .inline)  // Hide the navigation bar title
+    }
+}
+
+struct LoginInstructionsView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoginInstructionsView()
+    }
+}

--- a/SustainU/Views/LoginView.swift
+++ b/SustainU/Views/LoginView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 struct LoginView: View {
     @ObservedObject var viewModel: LoginViewModel
-    
+    @State private var showInstructions = false  // New state variable
+
     var body: some View {
         VStack {
             Spacer()
@@ -36,6 +37,20 @@ struct LoginView: View {
                         .background(Color("greenLogoColor"))
                         .cornerRadius(15.0)
                 }
+                
+                // New "Login Instructions" link
+                Button(action: {
+                    showInstructions = true  // Show the instructions view when tapped
+                }) {
+                    Text("Login Instructions")
+                        .font(.subheadline)
+                        .foregroundColor(.blue)
+                        .underline()
+                }
+                .padding(.top, 10)
+                .sheet(isPresented: $showInstructions) {
+                    LoginInstructionsView()  // Present the instructions view
+                }
             } else {
                 Text("No internet connection")
                     .foregroundColor(.red)
@@ -59,7 +74,6 @@ struct LoginView: View {
         }
         .onChange(of: viewModel.isConnected) { isConnected in
             if isConnected {
-                // Ejecuta acciones cuando se recupere la conexión
                 viewModel.showBackOnlineMessage = true
             }
         }
@@ -73,7 +87,7 @@ struct LoginView: View {
                         .background(Color.green)
                         .cornerRadius(8)
                         .transition(.opacity)
-                        .animation(.easeInOut)
+                        .animation(.easeInOut, value: viewModel.showBackOnlineMessage)
                         .onAppear {
                             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                                 viewModel.showBackOnlineMessage = false


### PR DESCRIPTION
- Added a "Login Instructions" link below the "Log in / Sign up" button in LoginView.
- Created a new SwiftUI view LoginInstructionsView to display the login instructions in a modal sheet.
- Included a showInstructions state variable in LoginView to control the presentation of the instructions view.
- Styled the link to resemble a hyperlink with blue text and underline.
- Added a close button to LoginInstructionsView for easy dismissal.
- Adjusted layout and padding for consistent styling.
- Enhanced user experience by providing guidance on the correct login and registration format, including domain requirements, character restrictions, and name constraints.